### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -3,6 +3,9 @@ name: Terraform Build Workflow
 on:
   workflow_dispatch:  # Trigger workflow manually from GitHub Actions
 
+permissions:
+  contents: read
+
 jobs:
   terraform:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vishaldpw/terraform-CICD/security/code-scanning/1](https://github.com/vishaldpw/terraform-CICD/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting it to the least privileges required. Since the workflow does not use the `GITHUB_TOKEN` for write operations, the permissions can be set to `contents: read`. This ensures that the token cannot be used to modify repository contents or perform other write actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
